### PR TITLE
Refactor vigneron job logic and tighten security

### DIFF
--- a/AsVigneron/client/gestion.lua
+++ b/AsVigneron/client/gestion.lua
@@ -16,6 +16,7 @@ local isGestionMenuOpen = false
 local employees = {}
 local selectedEmployee = nil
 local canInteract = true
+local PlayerData = {}
 
 -- Fonction pour afficher une notification native
 local function astrxwShowNativeNotification(msg)

--- a/AsVigneron/client/main.lua
+++ b/AsVigneron/client/main.lua
@@ -139,24 +139,6 @@ AddEventHandler('esx:setJob', function(job)
 
     CreateBlipsForJob()
 end)
-
-
-
-function CreateBlipsForJob()
-    for k, v in pairs(Config.Zones) do
-        if Config.BlipsVisibleForAll or (PlayerData.job and PlayerData.job.name == 'vigneron') then
-            local blip = AddBlipForCoord(v.Pos.x, v.Pos.y, v.Pos.z)
-            SetBlipSprite(blip, v.Blip.Sprite)
-            SetBlipDisplay(blip, 4)
-            SetBlipScale(blip, v.Blip.Scale)
-            SetBlipColour(blip, v.Blip.Color)
-            SetBlipAsShortRange(blip, true)
-            BeginTextCommandSetBlipName("STRING")
-            AddTextComponentString(v.Blip.Name)
-            EndTextCommandSetBlipName(blip)
-        end
-    end
-end
 -- Mise à jour de l'état de service
 RegisterNetEvent('vigneron:updateDutyStatus')
 AddEventHandler('vigneron:updateDutyStatus', function(status)

--- a/AsVigneron/client/menu.lua
+++ b/AsVigneron/client/menu.lua
@@ -45,7 +45,6 @@ local function astrxwOpenVenteMenu()
             venteBlip = astrxwCreateBlip(ventePoint, "Point de Vente")
             SetNewWaypoint(ventePoint.x, ventePoint.y)
             astrxwShowNativeNotification("Allez au point de vente marqué sur la carte.", "CHAR_SOCIAL_CLUB", 1)
-            TriggerServerEvent('vigneron:startVente')
         else
             astrxwShowNativeNotification("~r~Vous devez être dans un " .. Config.VenteVehicle .. " pour commencer la vente.", "CHAR_SOCIAL_CLUB", 1)
         end
@@ -67,8 +66,7 @@ end
 
 
 local function astrxwCompleteVente()
-    astrxwShowNativeNotification("La vente vous a rapporté " .. Config.VentePricePerItem .. "$", "CHAR_SOCIAL_CLUB", 1)
-    TriggerServerEvent('vigneron:payPlayer')
+    TriggerServerEvent('vigneron:startVente')
 end
 
 

--- a/AsVigneron/fxmanifest.lua
+++ b/AsVigneron/fxmanifest.lua
@@ -20,8 +20,6 @@ client_scripts {
     "src/menu/items/*.lua",
 
     "src/menu/panels/*.lua",
-
-    "src/menu/panels/*.lua",
     "src/menu/windows/*.lua",
 
 }

--- a/AsVigneron/server/main.lua
+++ b/AsVigneron/server/main.lua
@@ -33,17 +33,23 @@ end)
 
 RegisterServerEvent('vigneron:startVente')
 AddEventHandler('vigneron:startVente', function()
-    local _source = source
-    local xPlayer = ESX.GetPlayerFromId(_source)
-    if xPlayer then
-        local grapes = xPlayer.getInventoryItem('raisin').count
-        if grapes >= 1 then
-        Citizen.Wait(2000)
-        local grapes = math.random(1, 5)
-        xPlayer.removeInventoryItem('vine', 2)
-        astrxwSendDiscordEmbed("Vente démarrée par " .. xPlayer.getName())
+    local xPlayer = ESX.GetPlayerFromId(source)
+    if not xPlayer or xPlayer.job.name ~= 'vigneron' then
+        return
     end
-end
+
+    local vine = xPlayer.getInventoryItem('vine')
+    if vine.count <= 0 then
+        TriggerClientEvent('esx:showNotification', source, "~r~Vous n'avez pas de vin à vendre.")
+        return
+    end
+
+    xPlayer.removeInventoryItem('vine', 1)
+    Citizen.Wait(2000)
+    local amount = Config.VentePricePerItem
+    xPlayer.addMoney(amount)
+    TriggerClientEvent('esx:showNotification', source, 'Vous avez vendu ~g~1 bouteille~s~ pour ~g~$' .. amount)
+    astrxwSendDiscordEmbed("Vente par " .. xPlayer.getName() .. " pour $" .. amount)
 end)
 
 
@@ -80,8 +86,6 @@ end)
 
 
 
-ESX = exports["es_extended"]:getSharedObject()
-
 ESX.RegisterServerCallback('vigneron:getEmployees', function(source, cb)
     local employees = {}
     local xPlayers = ESX.GetExtendedPlayers()
@@ -103,6 +107,10 @@ end)
 RegisterNetEvent('vigneron:promoteEmployee')
 AddEventHandler('vigneron:promoteEmployee', function(identifier)
     local xPlayer = ESX.GetPlayerFromId(source)
+    if not xPlayer or xPlayer.job.name ~= 'vigneron' or xPlayer.job.grade_name ~= 'boss' then
+        TriggerClientEvent('esx:showNotification', source, "~r~Vous n'avez pas les permissions.")
+        return
+    end
 
     MySQL.Async.fetchScalar('SELECT job_grade FROM users WHERE identifier = @identifier', {
         ['@identifier'] = identifier
@@ -136,6 +144,10 @@ end)
 RegisterNetEvent('vigneron:demoteEmployee')
 AddEventHandler('vigneron:demoteEmployee', function(identifier)
     local xPlayer = ESX.GetPlayerFromId(source)
+    if not xPlayer or xPlayer.job.name ~= 'vigneron' or xPlayer.job.grade_name ~= 'boss' then
+        TriggerClientEvent('esx:showNotification', source, "~r~Vous n'avez pas les permissions.")
+        return
+    end
 
     MySQL.Async.fetchScalar('SELECT job_grade FROM users WHERE identifier = @identifier', {
         ['@identifier'] = identifier
@@ -164,13 +176,17 @@ end)
 RegisterNetEvent('vigneron:fireEmployee')
 AddEventHandler('vigneron:fireEmployee', function(identifier)
     local xPlayer = ESX.GetPlayerFromId(source)
+    if not xPlayer or xPlayer.job.name ~= 'vigneron' or xPlayer.job.grade_name ~= 'boss' then
+        TriggerClientEvent('esx:showNotification', source, "~r~Vous n'avez pas les permissions.")
+        return
+    end
 
     MySQL.Async.execute('UPDATE users SET job = @job, job_grade = 0 WHERE identifier = @identifier', {
         ['@identifier'] = identifier,
         ['@job'] = 'unemployed'
     }, function(rowsChanged)
         if rowsChanged > 0 then
-        
+
             local firedPlayer = ESX.GetPlayerFromIdentifier(identifier)
             if firedPlayer then
                 firedPlayer.setJob('unemployed', 0)
@@ -193,15 +209,4 @@ ESX.RegisterServerCallback('vigneron:checkJob', function(source, cb)
 end)
 
 
-
-RegisterServerEvent('vigneron:payPlayer')
-AddEventHandler('vigneron:payPlayer', function()
-    local xPlayer = ESX.GetPlayerFromId(source)
-    if xPlayer then
-        local amount = Config.VentePricePerItem
-        xPlayer.addMoney(amount)
-        TriggerClientEvent('esx:showNotification', source, "Vous avez reçu ~g~$" .. amount)
-        astrxwSendDiscordEmbed("Vente terminée par " .. xPlayer.getName() .. " pour $" .. amount)
-    end
-end)
 


### PR DESCRIPTION
## Summary
- Fix wine sale logic to validate inventory, pay players, and log sales
- Restrict employee management events to vigneron bosses only
- Clean up duplicate blip logic and manifest entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bdee471b483209f63e2b9ca4c1cdf